### PR TITLE
Enable streaming output to TTY::Logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Allow editing logger configuration at runtime ([#10](https://github.com/piotrmurach/tty-logger/pull/10))
+* Support for the `<<` streaming operator ([#9](https://github.com/piotrmurach/tty-logger/pull/9)))
 
 ## [v0.3.0] - 2020-01-01
 

--- a/lib/tty/logger.rb
+++ b/lib/tty/logger.rb
@@ -211,6 +211,24 @@ module TTY
       compare_levels(level, other_level) != :gt
     end
 
+    # Logs streaming output.
+    #
+    # @example
+    #   logger << "Example output"
+    #
+    # @api public
+    def write(*msg)
+      event = Event.new(filter(*msg))
+
+      @ready_handlers.each do |handler|
+        handler.(event)
+      end
+
+      self
+    end
+
+    alias_method :<<, :write
+
     # Log a message given the severtiy level
     #
     # @example
@@ -236,7 +254,7 @@ module TTY
         level: current_level,
         time: Time.now,
         pid: Process.pid,
-        name: /<top\s+\(required\)>|<main>/ =~ label ? current_level : label,
+        name: /<top\s+\(required\)>|<main>|<</ =~ label ? current_level : label,
         path: loc.path,
         lineno: loc.lineno,
         method: loc.base_label

--- a/lib/tty/logger/event.rb
+++ b/lib/tty/logger/event.rb
@@ -11,7 +11,7 @@ module TTY
 
       attr_reader :backtrace
 
-      def initialize(message, fields, metadata)
+      def initialize(message, fields = {}, metadata = {})
         @message = message
         @fields = fields
         @metadata = metadata

--- a/lib/tty/logger/handlers/console.rb
+++ b/lib/tty/logger/handlers/console.rb
@@ -114,8 +114,10 @@ module TTY
             end
           end
           fmt << ARROW unless config.metadata.empty?
-          fmt << color.(style[:symbol])
-          fmt << color.(style[:label]) + (" " * style[:levelpad])
+          unless style.empty?
+            fmt << color.(style[:symbol])
+            fmt << color.(style[:label]) + (" " * style[:levelpad])
+          end
           fmt << "%-25s" % event.message.join(" ")
           unless event.fields.empty?
             pattern, replacement = *@color_pattern
@@ -148,11 +150,11 @@ module TTY
         #
         # @api private
         def configure_styles(event)
-          style = STYLES.fetch(event.metadata[:name].to_sym, {}).dup
-          (@styles[event.metadata[:name].to_sym] || {}).each do |k, v|
-            style[k] = v
-          end
-          style
+          return {}  if event.metadata[:name].nil?
+
+          STYLES.fetch(event.metadata[:name].to_sym, {})
+            .dup
+            .merge!(@styles[event.metadata[:name].to_sym] || {})
         end
 
         def configure_color(style)

--- a/spec/unit/log_spec.rb
+++ b/spec/unit/log_spec.rb
@@ -200,4 +200,14 @@ RSpec.describe TTY::Logger, "#log" do
       end
     }.to raise_error(TTY::Logger::Error, "Already defined log type :success")
   end
+
+  it "logs streaming output" do
+    logger = TTY::Logger.new(output: output)
+
+    logger << "Deploying..."
+
+    expect(output.string).to eq([
+      "Deploying...             \n"
+    ].join)
+  end
 end


### PR DESCRIPTION
### Describe the change

As requested on piotrmurach/tty-command#53, this pull request enables `TTY::Logger` to stream output, via the `<<` operator.

### Why are we doing this?

piotrmurach/tty-command#53

### Benefits

This pull request will enable `TTY::Command` to interoperate with `TTY::Logger`.

### Drawbacks

`<<` assumes the output will be of `debug` type, as there is not a defined level.

### Requirements
Put an X between brackets on each line if you have done the item:
- [x] Tests written & passing locally?
- [ ] Code style checked?
  - I've not tried to run `rubocop` because there isn't a version set on this project.
- [x] Rebased with `master` branch?
- [x] Documentation updated?
