### PR TITLE
Allow editing logger configuration at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### Added
+
+* Allow editing logger configuration at runtime ([#10](https://github.com/piotrmurach/tty-logger/pull/10))
+
 ## [v0.3.0] - 2020-01-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ logger.wait { ["Ready to deploy", {app: "myapp", env: "prod"}] }
 
 ### 2.4 Configuration
 
-All the configuration options can be changed globally via `configure` or per logger instance via object initialization.
+All the configuration options can be changed globally via `configure` or per logger instance.
 
 * `:filters` - the storage of placeholders to filter sensitive data out from the logs. Defaults to `{}`.
 * `:formatter` - the formatter used to display structured data. Defaults to `:text`. See [Formatters](#27-formatters) for more details.
@@ -361,6 +361,14 @@ Or if you wish to setup configuration per logger instance use block:
 logger = TTY::Logger.new do |config|
   config.max_bytes = 2**20
   config.metadata = [:all]
+end
+```
+
+You can also change the logger's configuration at runtime:
+
+```ruby
+logger.configure do |config|
+  config.level = :debug
 end
 ```
 

--- a/lib/tty/logger.rb
+++ b/lib/tty/logger.rb
@@ -69,6 +69,13 @@ module TTY
       yield config
     end
 
+    # Instance logger configuration
+    #
+    # @api public
+    def configure
+      yield @config
+    end
+
     # Create a logger instance
     #
     # @example

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -73,6 +73,15 @@ RSpec.describe TTY::Logger::Config do
     })
   end
 
+  it "yields logger's own configuration" do
+    logger = TTY::Logger.new(output: output)
+    config = double(:configure)
+    allow(logger).to receive(:configure).and_yield(config)
+    expect { |block|
+      logger.configure(&block)
+    }.to yield_with_args(config)
+  end
+
   it "yields configuration instance" do
     config = double(:config)
     allow(TTY::Logger).to receive(:config).and_return(config)


### PR DESCRIPTION
### Describe the change

This pull request fixes #7 by allowing edits to the logger's configuration at runtime.

### Why are we doing this?

`TTY::Logger` doesn't currently let one edit its filtering if a parameter isn't known at initialization.

### Benefits

`TTY::Logger` can now be adjusted freely at runtime.

### Drawbacks

None that I know of.

### Requirements
Put an X between brackets on each line if you have done the item:
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
