### PR TITLE
Select event name from valid log types or current level

### DIFF
--- a/lib/tty/logger.rb
+++ b/lib/tty/logger.rb
@@ -104,6 +104,7 @@ module TTY
       @data_filter = DataFilter.new(@config.filters.data,
                                     mask: @config.filters.mask)
 
+      @types = LOG_TYPES.dup
       @config.types.each do |name, log_level|
         add_type(name, log_level)
       end
@@ -120,9 +121,11 @@ module TTY
     #
     # @api private
     def add_type(name, log_level)
-      if respond_to?(name)
+      if @types.include?(name)
         raise Error, "Already defined log type #{name.inspect}"
       end
+
+      @types[name.to_sym] = log_level
       self.class.define_level(name, log_level)
     end
 
@@ -254,7 +257,7 @@ module TTY
         level: current_level,
         time: Time.now,
         pid: Process.pid,
-        name: /<top\s+\(required\)>|<main>|<</ =~ label ? current_level : label,
+        name: @types.include?(label.to_sym) ? label : current_level,
         path: loc.path,
         lineno: loc.lineno,
         method: loc.base_label

--- a/spec/unit/log_spec.rb
+++ b/spec/unit/log_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe TTY::Logger, "#log" do
     ].join)
   end
 
+  it "logs when called from another method" do
+    logger = TTY::Logger.new(output: output) do |config|
+      config.level = :debug
+    end
+
+    log_wrapper(logger).call(:debug, "Deploying...")
+
+    expect(output.string).to eq([
+      "\e[36m#{styles[:debug][:symbol]}\e[0m ",
+      "\e[36mdebug\e[0m   ",
+      "Deploying...             \n"
+    ].join)
+  end
+
+  def log_wrapper(logger)
+    ->(level, message) do
+      logger.log(level, message)
+    end
+  end
+
   it "logs a message at debug level" do
     logger = TTY::Logger.new(output: output) do |config|
       config.level = :debug


### PR DESCRIPTION
### Describe the change
Instead of pattern matching against the top stack frame's label, this PR matches the label against the valid list of log types before falling back to the `current_level`.

### Why are we doing this?
I ran into this while trying to write an adapter for concurrent-ruby's log output. Their logs are generated here: https://github.com/ruby-concurrency/concurrent-ruby/blob/c1114a0c6891d9634f019f1f9fe58dcae8658964/lib/concurrent-ruby/concurrent/concern/logging.rb#L25

Here's my example code (where `logger` is a `TTY::Logger`):
```ruby
def execute(input: $stdin, output: $stderr)
  Concurrent.global_logger = ->(loglevel, progname, message = nil, &block) do
    logger.log(
      logger.number_to_level(loglevel),
      [message],
      &block
    )
  end

  #more code
end

```

### Benefits
This should cause `log` to select the correct name even when called farther up the stack from where the event of interest was generated.

### Drawbacks
I can't see any. Every case that would have matched the previous regex should be handled by the new types allowlist.

### Requirements
Put an X between brackets on each line if you have done the item:
- [x] Tests written & passing locally?
- [ ] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?

I'm not sure this needs any documentation. For me, it makes the code align more with my expectations from reading the existing docs.