### PR TITLE
Adds message_format config option to customize how messages are displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ styled_logger.error("Custom error")
 # ! Dooh    Custom error
 ```
 
-To increase message padding to a percentage of terminal width (depends on https://github.com/piotrmurach/tty-screen/):
+To increase message padding to a percentage of terminal width (depends on [tty-screen](https://github.com/piotrmurach/tty-screen/)):
 
 ```ruby
 TTY::Logger.new do |config|

--- a/README.md
+++ b/README.md
@@ -348,7 +348,6 @@ All the configuration options can be changed globally via `configure` or per log
 * `:types` - the new custom log types. Defaults to `{}`.
 * `:date_format` - uses `strftime` format to display dates. Defaults to `"%F"`.
 * `:time_format` - uses `strftime` format to display times. Defaults to `"%T.%3N"`.
-* `:message_format` - uses `sprintf` format display messages. Defaults to `"%-25s"`.
 
 For example, to configure `:max_bytes`, `:level` and `:metadata` for all logger instances do:
 
@@ -552,6 +551,7 @@ The console handler prints log messages to the console. It supports the followin
 * `:styles` - a hash of styling options.
 * `:formatter` - the formatter for log messages. Defaults to `:text`
 * `:output` - the device to log error messages to. Defaults to `$stderr`
+* `:message_format` - uses `sprintf` format to display messages. Defaults to `"%-25s"`.
 
 The supported options in the `:styles` are:
 
@@ -605,6 +605,15 @@ styled_logger.error("Custom error")
 # =>
 # + Ohh yes Custom success
 # ! Dooh    Custom error
+```
+
+To increase message padding to a percentage of terminal width (depends on https://github.com/piotrmurach/tty-screen/):
+
+```ruby
+TTY::Logger.new do |config|
+  padding = (TTY::Screen.columns * 0.4).to_i
+  config.handlers = [[:console, { message_format: "%-#{padding}s" }]]
+end
 ```
 
 #### 2.6.2 Stream handler

--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ logger.remove_handler(:console)
 The console handler prints log messages to the console. It supports the following options:
 
 * `:styles` - a hash of styling options.
+* `:message_padding` - the extra amount of padding used to display log message.
 * `:formatter` - the formatter for log messages. Defaults to `:text`
 * `:output` - the device to log error messages to. Defaults to `$stderr`
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,9 @@ All the configuration options can be changed globally via `configure` or per log
 * `:max_depth` - the maximum depth for nested structured data. Defaults to `3`.
 * `:metadata` - the meta info to display before the message, can be `:pid`, `:date`, `:time` or `:file`. Defaults to empty array `[]`, no metadata. Setting this to `:all` will print all the metadata.
 * `:types` - the new custom log types. Defaults to `{}`.
+* `:date_format` - uses `strftime` format to display dates. Defaults to `"%F"`.
+* `:time_format` - uses `strftime` format to display times. Defaults to `"%T.%3N"`.
+* `:message_format` - uses `sprintf` format display messages. Defaults to `"%-25s"`.
 
 For example, to configure `:max_bytes`, `:level` and `:metadata` for all logger instances do:
 
@@ -547,7 +550,6 @@ logger.remove_handler(:console)
 The console handler prints log messages to the console. It supports the following options:
 
 * `:styles` - a hash of styling options.
-* `:message_padding` - the extra amount of padding used to display log message.
 * `:formatter` - the formatter for log messages. Defaults to `:text`
 * `:output` - the device to log error messages to. Defaults to `$stderr`
 

--- a/lib/tty/logger/config.rb
+++ b/lib/tty/logger/config.rb
@@ -7,11 +7,14 @@ module TTY
     class Config
       FILTERED = "[FILTERED]"
 
-      # The format used for date display
+      # The format used for date display. uses strftime format
       attr_accessor :date_format
 
-      # The format used for time display
+      # The format used for time display. uses strftime format
       attr_accessor :time_format
+
+      # The format used for message display. uses sprintf format
+      attr_accessor :message_format
 
       # The filters to hide sensitive data from the messages and data.
       attr_accessor :filters
@@ -52,6 +55,7 @@ module TTY
         @formatter = options.fetch(:formatter) { :text }
         @date_format = options.fetch(:date_format) { "%F" }
         @time_format = options.fetch(:time_format) { "%T.%3N" }
+        @message_format = options.fetch(:message_format) { "%-25s" }
         @output = options.fetch(:output) { $stderr }
         @types = options.fetch(:types) { {} }
       end
@@ -92,6 +96,8 @@ module TTY
       def to_proc
         -> (config) {
           config.date_format = @date_format.dup
+          config.time_format = @time_format.dup
+          config.message_format = @message_format.dup
           config.filters = @filters.dup
           config.formatter = @formatter
           config.handlers = @handlers.dup
@@ -100,7 +106,6 @@ module TTY
           config.max_depth = @max_depth
           config.metadata = @metadata.dup
           config.output = @output.dup
-          config.time_format = @time_format.dup
           config.types = @types.dup
           config
         }

--- a/lib/tty/logger/config.rb
+++ b/lib/tty/logger/config.rb
@@ -13,9 +13,6 @@ module TTY
       # The format used for time display. uses strftime format
       attr_accessor :time_format
 
-      # The format used for message display. uses sprintf format
-      attr_accessor :message_format
-
       # The filters to hide sensitive data from the messages and data.
       attr_accessor :filters
 
@@ -31,7 +28,7 @@ module TTY
       # The maximum message size to be logged in bytes. Defaults to 8192
       attr_accessor :max_bytes
 
-      # The maximum depth for formattin array and hash objects. Defaults to 3
+      # The maximum depth for formatting array and hash objects. Defaults to 3
       attr_accessor :max_depth
 
       # The meta info to display, can be :date, :time, :file, :pid. Defaults to []
@@ -55,7 +52,6 @@ module TTY
         @formatter = options.fetch(:formatter) { :text }
         @date_format = options.fetch(:date_format) { "%F" }
         @time_format = options.fetch(:time_format) { "%T.%3N" }
-        @message_format = options.fetch(:message_format) { "%-25s" }
         @output = options.fetch(:output) { $stderr }
         @types = options.fetch(:types) { {} }
       end
@@ -97,7 +93,6 @@ module TTY
         -> (config) {
           config.date_format = @date_format.dup
           config.time_format = @time_format.dup
-          config.message_format = @message_format.dup
           config.filters = @filters.dup
           config.formatter = @formatter
           config.handlers = @handlers.dup

--- a/lib/tty/logger/handlers/console.rb
+++ b/lib/tty/logger/handlers/console.rb
@@ -72,14 +72,13 @@ module TTY
         attr_reader :level
 
         def initialize(output: $stderr, formatter: nil, config: nil, level: nil,
-                       styles: {}, message_padding: 25)
+                       styles: {})
           @output = Array[output].flatten
           @formatter = coerce_formatter(formatter || config.formatter).new
           @formatter_name = @formatter.class.name.split("::").last.downcase
           @color_pattern = COLOR_PATTERNS[@formatter_name.to_sym]
           @config = config
           @styles = styles
-          @message_padding = message_padding
           @level = level || @config.level
           @mutex = Mutex.new
           @pastel = Pastel.new
@@ -119,7 +118,7 @@ module TTY
             fmt << color.(style[:symbol])
             fmt << color.(style[:label]) + (" " * style[:levelpad])
           end
-          fmt << "%-#{@message_padding}s" % event.message.join(" ")
+          fmt << config.message_format % event.message.join(" ")
           unless event.fields.empty?
             pattern, replacement = *@color_pattern
             fmt << @formatter.dump(event.fields, max_bytes: config.max_bytes,

--- a/lib/tty/logger/handlers/console.rb
+++ b/lib/tty/logger/handlers/console.rb
@@ -72,13 +72,14 @@ module TTY
         attr_reader :level
 
         def initialize(output: $stderr, formatter: nil, config: nil, level: nil,
-                       styles: {})
+                       styles: {}, message_padding: 100)
           @output = Array[output].flatten
           @formatter = coerce_formatter(formatter || config.formatter).new
           @formatter_name = @formatter.class.name.split("::").last.downcase
           @color_pattern = COLOR_PATTERNS[@formatter_name.to_sym]
           @config = config
           @styles = styles
+          @message_padding = message_padding
           @level = level || @config.level
           @mutex = Mutex.new
           @pastel = Pastel.new
@@ -118,7 +119,7 @@ module TTY
             fmt << color.(style[:symbol])
             fmt << color.(style[:label]) + (" " * style[:levelpad])
           end
-          fmt << "%-25s" % event.message.join(" ")
+          fmt << "%-#{@message_padding}s" % event.message.join(" ")
           unless event.fields.empty?
             pattern, replacement = *@color_pattern
             fmt << @formatter.dump(event.fields, max_bytes: config.max_bytes,

--- a/lib/tty/logger/handlers/console.rb
+++ b/lib/tty/logger/handlers/console.rb
@@ -72,7 +72,7 @@ module TTY
         attr_reader :level
 
         def initialize(output: $stderr, formatter: nil, config: nil, level: nil,
-                       styles: {}, message_padding: 100)
+                       styles: {}, message_padding: 25)
           @output = Array[output].flatten
           @formatter = coerce_formatter(formatter || config.formatter).new
           @formatter_name = @formatter.class.name.split("::").last.downcase

--- a/lib/tty/logger/handlers/console.rb
+++ b/lib/tty/logger/handlers/console.rb
@@ -65,14 +65,10 @@ module TTY
           json: [JSON_REGEXP, ->(c) { "\"" + c.("\\1") + "\"" }]
         }.freeze
 
-        attr_reader :output
-
-        attr_reader :config
-
-        attr_reader :level
+        attr_reader :output, :config, :level, :message_format
 
         def initialize(output: $stderr, formatter: nil, config: nil, level: nil,
-                       styles: {})
+                       styles: {}, message_format: "%-25s")
           @output = Array[output].flatten
           @formatter = coerce_formatter(formatter || config.formatter).new
           @formatter_name = @formatter.class.name.split("::").last.downcase
@@ -82,6 +78,7 @@ module TTY
           @level = level || @config.level
           @mutex = Mutex.new
           @pastel = Pastel.new
+          @message_format = message_format
         end
 
         # Handle log event output in format
@@ -118,7 +115,7 @@ module TTY
             fmt << color.(style[:symbol])
             fmt << color.(style[:label]) + (" " * style[:levelpad])
           end
-          fmt << config.message_format % event.message.join(" ")
+          fmt << message_format % event.message.join(" ")
           unless event.fields.empty?
             pattern, replacement = *@color_pattern
             fmt << @formatter.dump(event.fields, max_bytes: config.max_bytes,

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -45,11 +45,6 @@ RSpec.describe TTY::Logger::Config do
     expect(config.date_format).to eq("%F")
   end
 
-  it "defaults message_format to left aligned with 25 padding" do
-    config = described_class.new
-    expect(config.message_format).to eq("%-25s")
-  end
-
   it "defaults output to stderr" do
     config = described_class.new
     expect(config.output).to eq($stderr)

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe TTY::Logger::Config do
     expect(config.date_format).to eq("%F")
   end
 
+  it "defaults message_format to left aligned with 25 padding" do
+    config = described_class.new
+    expect(config.message_format).to eq("%-25s")
+  end
+
   it "defaults output to stderr" do
     config = described_class.new
     expect(config.output).to eq($stderr)

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -45,37 +45,44 @@ RSpec.describe TTY::Logger, 'handlers' do
       "Logging                  \n"].join)
   end
 
-  it "defaults message_padding to 25 spaces" do
+  it "defaults format to 25 space padded message" do
     logger = TTY::Logger.new(output: output)
-    message = "Logging"
-    expected_padding = 25 - message.size
 
-    logger.info(message)
+    logger.info("Logging")
 
-    expect(output.string).to eq("\e[32m#{styles[:info][:symbol]}\e[0m \e[32minfo\e[0m    Logging#{' ' * expected_padding}\n")
+    expect(output.string).to eq(
+      "\e[32m#{styles[:info][:symbol]}" \
+      "\e[0m \e[32minfo\e[0m    " \
+      "Logging                  \n"
+    )
   end
 
-  it "changes default message_padding" do
-    padding = 10
+  it "changes default message_format" do
     logger = TTY::Logger.new(output: output) do |config|
-      config.handlers = [[:console, {message_padding: padding}]]
-    end
-    message = "Logging"
-    expected_padding = padding - message.size
-
-    logger.info(message)
-
-    expect(output.string).to eq("\e[32m#{styles[:info][:symbol]}\e[0m \e[32minfo\e[0m    Logging#{' ' * expected_padding}\n")
-  end
-
-  it "overflows padding when necessary" do
-    logger = TTY::Logger.new(output: output) do |config|
-      config.handlers = [[:console, {message_padding: 0}]]
+      config.message_format = "%-10s"
     end
 
     logger.info("Logging")
 
-    expect(output.string).to eq("\e[32m#{styles[:info][:symbol]}\e[0m \e[32minfo\e[0m    Logging\n")
+    expect(output.string).to eq(
+      "\e[32m#{styles[:info][:symbol]}" \
+      "\e[0m \e[32minfo\e[0m    " \
+      "Logging   \n"
+    )
+  end
+
+  it "overflows padding when necessary" do
+    logger = TTY::Logger.new(output: output) do |config|
+      config.message_format = "%-0s"
+    end
+
+    logger.info("Logging")
+
+    expect(output.string).to eq(
+      "\e[32m#{styles[:info][:symbol]}" \
+      "\e[0m \e[32minfo\e[0m    " \
+      "Logging\n"
+    )
   end
 
   it "logs different levels for each handler" do

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -45,6 +45,39 @@ RSpec.describe TTY::Logger, 'handlers' do
       "Logging                  \n"].join)
   end
 
+  it "defaults message_padding to 25 spaces" do
+    logger = TTY::Logger.new(output: output)
+    message = "Logging"
+    expected_padding = 25 - message.size
+
+    logger.info(message)
+
+    expect(output.string).to eq("\e[32m#{styles[:info][:symbol]}\e[0m \e[32minfo\e[0m    Logging#{' ' * expected_padding}\n")
+  end
+
+  it "changes default message_padding" do
+    padding = 10
+    logger = TTY::Logger.new(output: output) do |config|
+      config.handlers = [[:console, {message_padding: padding}]]
+    end
+    message = "Logging"
+    expected_padding = padding - message.size
+
+    logger.info(message)
+
+    expect(output.string).to eq("\e[32m#{styles[:info][:symbol]}\e[0m \e[32minfo\e[0m    Logging#{' ' * expected_padding}\n")
+  end
+
+  it "overflows padding when necessary" do
+    logger = TTY::Logger.new(output: output) do |config|
+      config.handlers = [[:console, {message_padding: 0}]]
+    end
+
+    logger.info("Logging")
+
+    expect(output.string).to eq("\e[32m#{styles[:info][:symbol]}\e[0m \e[32minfo\e[0m    Logging\n")
+  end
+
   it "logs different levels for each handler" do
     logger = TTY::Logger.new(output: output) do |config|
       config.handlers = [

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe TTY::Logger, 'handlers' do
 
   it "changes default message_format" do
     logger = TTY::Logger.new(output: output) do |config|
-      config.message_format = "%-10s"
+      config.handlers = [[:console, { message_format: "%-10s" }]]
     end
 
     logger.info("Logging")
@@ -73,7 +73,7 @@ RSpec.describe TTY::Logger, 'handlers' do
 
   it "overflows padding when necessary" do
     logger = TTY::Logger.new(output: output) do |config|
-      config.message_format = "%-0s"
+      config.handlers = [[:console, { message_format: "%-0s" }]]
     end
 
     logger.info("Logging")


### PR DESCRIPTION
### Describe the change
Adds message_format configuration option


### Why are we doing this?

For long messages, it's nice to add extra padding so that more fields will
tend to line up vertically. the intent of this is to pair with something like
https://github.com/piotrmurach/tty-screen to use the most available screen space

For example, for an application that has about as much data in messages as fields:

```ruby
TTY::Logger.new do |config|
  config.message_format = '%-100s'
end
```

Closes: #12 

### Benefits
This will allow folks to improve the readability of their messages in the console

### Drawbacks
This might be a sharp config option that allows for somewhat nonsensical inputs

### Requirements
Put an X between brackets on each line if you have done the item:
[x] Tests written & passing locally?
[x] Code style checked?
[x] Rebased with `master` branch?
[x] Documentation updated?
