### PR TITLE
Fix runtime log level changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+
+* Fix console and stream handlers to respect logger runtime log-level changes
+
 ## [v0.6.0] - 2020-12-05
 
 ### Added

--- a/lib/tty/logger/handlers/console.rb
+++ b/lib/tty/logger/handlers/console.rb
@@ -73,10 +73,6 @@ module TTY
         # @api private
         attr_reader :config
 
-        # The logging level
-        # @api private
-        attr_reader :level
-
         # The format for the message
         # @api private
         attr_reader :message_format
@@ -89,7 +85,7 @@ module TTY
           @color_pattern = COLOR_PATTERNS[@formatter_name.to_sym]
           @config = config
           @styles = styles
-          @level = level || @config.level
+          @level = level
           @mutex = Mutex.new
           @pastel = Pastel.new(enabled: enable_color)
           @message_format = message_format
@@ -143,6 +139,11 @@ module TTY
           output.each { |out| out.puts fmt.join(" ") }
         ensure
           @mutex.unlock
+        end
+
+        # @api private
+        def level
+          @level || @config.level
         end
 
         private

--- a/lib/tty/logger/handlers/stream.rb
+++ b/lib/tty/logger/handlers/stream.rb
@@ -12,13 +12,11 @@ module TTY
 
         attr_reader :config
 
-        attr_reader :level
-
         def initialize(output: $stderr, formatter: nil, config: nil, level: nil)
           @output = Array[output].flatten
           @formatter = coerce_formatter(formatter || config.formatter).new
           @config = config
-          @level = level || @config.level
+          @level = level
           @mutex = Mutex.new
         end
 
@@ -56,6 +54,10 @@ module TTY
           end
         ensure
           @mutex.unlock
+        end
+
+        def level
+          @level || @config.level
         end
       end # Stream
     end # Handlers

--- a/spec/unit/handler_spec.rb
+++ b/spec/unit/handler_spec.rb
@@ -111,6 +111,27 @@ RSpec.describe TTY::Logger, 'handlers' do
     ].join)
   end
 
+  it "respects logger instance-level log level configuration changes" do
+    logger = TTY::Logger.new(output: output) do |config|
+      config.handlers = [
+        [:console, enable_color: false]
+      ]
+      config.level = :warn
+    end
+
+    logger.configure do |config|
+      config.level = :info
+    end
+
+    logger.info("Info")
+    logger.error("Error")
+
+    expect(output.string).to eq([
+      "#{styles[:info][:symbol]} info    Info                     \n",
+      "#{styles[:error][:symbol]} error   Error                    \n",
+    ].join)
+  end
+
   it "fails to coerce unknown object type into handler object" do
     expect {
       TTY::Logger.new do |config|

--- a/spec/unit/handlers/stream_spec.rb
+++ b/spec/unit/handlers/stream_spec.rb
@@ -71,4 +71,22 @@ RSpec.describe TTY::Logger, "#log" do
       "\"level\":\"info\",\"message\":\"Successfully deployed\"}\n"
     ].join)
   end
+
+  it "respects logger instance-level log level configuration changes" do
+    logger = TTY::Logger.new(output: output) do |config|
+      config.handlers = [:stream]
+    end
+
+    logger.configure do |config|
+      config.level = :debug
+    end
+
+    logger.info("Successfully deployed")
+    logger.debug("A debug message")
+
+    expect(output.string).to eq([
+      "level=info message=\"Successfully deployed\"\n",
+      "level=debug message=\"A debug message\"\n",
+    ].join)
+  end
 end


### PR DESCRIPTION
### Describe the change

The `console` and `stream` handlers currently do not respect runtime logger instance-level log level configuration changes as they store the instance-level log level which was set when they were initialized.

### Why are we doing this?

To permit dynamic log level changes to work as documented: https://github.com/piotrmurach/tty-logger/blob/master/README.md#24-configuration

### Benefits

- Fix documented behavior to work as documented.
- Permit greater flexibility in working with changing log levels.

### Drawbacks

I did not measure it, but this change likely results in a small performance hit as there is some additional logic run for every log message.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [ ] Code style checked?  Unsure what to do here - no Rubocop in project and the latest version reports a great many errors.
- [x] Rebased with `master` branch?
- [ ] Documentation updated?  Unneeded - fixes behavior to match documentation.
- [x] Changelog updated?
