### PR TITLE
Fix to show the name of log type correctly in Ruby 3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Unreleased
+
+### Fixed
+* Fix to show the name of log type correctly in Ruby 3.4 ([#18](https://github.com/piotrmurach/tty-logger/pull/18))
+
 ## [v0.6.0] - 2020-12-05
 
 ### Added

--- a/lib/tty/logger.rb
+++ b/lib/tty/logger.rb
@@ -261,7 +261,7 @@ module TTY
       end
       top_caller = caller_locations(1, 1)[0]
       loc = caller_locations(2, 1)[0] || top_caller
-      label = top_caller.label
+      label = top_caller.base_label
       metadata = {
         level: current_level,
         time: Time.now,


### PR DESCRIPTION
### Describe the change
This PR fixes an issue in Ruby 3.4 where TTY::Logger fails to display the correct log type name.

### Why are we doing this?

Suppose we run the following code:

```ruby
require 'tty-logger'

logger = TTY::Logger.new
logger.success "Deployed successfully"
```

in Ruby 3.3.5:

```console
✔ success Deployed successfully    
```

in Ruby 3.4.1:

```console
ℹ info    Deployed successfully    
```

This is likely due to changes in the behavior of `Thread::Backtrace::Location` returned by `caller_locations`.
https://github.com/ruby/ruby/blob/master/doc/NEWS/NEWS-3.4.0.md#compatibility-issues

### Benefits
We can use TTY::Logger in Ruby 3.4.

### Drawbacks
I hope nothing.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [x] Changelog updated?
